### PR TITLE
Text selection color & opacity fix

### DIFF
--- a/themes/one-dark.json
+++ b/themes/one-dark.json
@@ -135,7 +135,11 @@
         "warning": "#d19a66",
         "warning.background": "#1e2227",
         "warning.border": "#89734d",
-        "players": [],
+        "players": [
+          {
+            "selection": "#3e455270"
+          }
+        ],
         "syntax": {
           "comment": {
             "color": "#7F838C",


### PR DESCRIPTION
## Problems tackled in this PR
### The first issue:
Currently, when selecting code, the color is a blueish color as mentioned in this issue https://github.com/MordFustang21/zed-one-dark-pro/issues/19#issue-2459094338
![CleanShot 2024-08-17 at 03 17 26](https://github.com/user-attachments/assets/e10d0c29-1c23-4825-b95c-53a9d13b6a7b)

### The second issue:
When selecting text in documentation, the text becomes unreadable.
![CleanShot 2024-08-17 at 03 18 02](https://github.com/user-attachments/assets/ec116589-0ac6-4fd1-9c44-d71629ab8203)



## Proposed Solution
By specifying `selection` color under `players`, it seems to fix the issue. With my observation, the value `selection` takes is `#<hex_value><opacity>` where opacity is the %.
So with the color `#3e4552` and opacity of `70`%, the value expected is: `#3e455270`
```json
"experimental.theme_overrides": {
  "players": [
     {
      "selection": "#3e455270"
    }
  ]
}
```

## Result of this PR
### Resolved first issue:
![CleanShot 2024-08-17 at 02 55 37](https://github.com/user-attachments/assets/26694bda-8da5-46ef-b600-2fb0deb0a4e0)
### Resolved second issue:
![CleanShot 2024-08-17 at 03 18 33](https://github.com/user-attachments/assets/d66db45f-fcd7-45aa-9483-9105167b6183)

