### PR TITLE
update `hint` color

### DIFF
--- a/themes/one-dark.json
+++ b/themes/one-dark.json
@@ -108,7 +108,7 @@
         "hidden": null,
         "hidden.background": null,
         "hidden.border": null,
-        "hint": "#abb2bf",
+        "hint": "#7a849c",
         "hint.background": "#1e2227",
         "hint.border": "#013b64",
         "ignored": "#636b78",


### PR DESCRIPTION
The inlay `hint` color of rust is almost the same as variable color, so update it to distinguish them.

Before:
![image](https://github.com/user-attachments/assets/04d9de54-8f56-45fe-98c8-47caa4a0c203)
After:
![image](https://github.com/user-attachments/assets/9a372584-0af9-4593-b237-201878574ee0)
