### PR TITLE
Fix bracket background and search match color

### DIFF
--- a/themes/one-dark.json
+++ b/themes/one-dark.json
@@ -63,6 +63,7 @@
         "editor.active_wrap_guide": "#3e4452",
         "editor.document_highlight.read_background": null,
         "editor.document_highlight.write_background": null,
+        "editor.document_highlight.bracket_background": "#515a6b",
         "terminal.background": "#23272e",
         "terminal.foreground": null,
         "terminal.bright_foreground": null,

--- a/themes/one-dark.json
+++ b/themes/one-dark.json
@@ -42,7 +42,7 @@
         "tab_bar.background": "#1e2227",
         "tab.inactive_background": "#1e2227",
         "tab.active_background": "#23272e",
-        "search.match_background": "#74ade866",
+        "search.match_background": "#d19a6644",
         "panel.background": "#23272e",
         "panel.focused_border": null,
         "scrollbar_thumb.background": "#4e5666",


### PR DESCRIPTION
This PR changes the `search.match_background` color and adds `editor.document_highlight.bracket_background` color because it was missing and the default color was used.

| before | after|
|---------|---------|
| ![image](https://github.com/user-attachments/assets/878365b2-f71d-407b-8b18-9ad3501bc514) | ![image](https://github.com/user-attachments/assets/593969ea-9f4f-4c3c-9d44-664a1a07db9f) |
| ![image](https://github.com/user-attachments/assets/6346074e-55f6-4999-a51d-0bd5e49f800c) | ![image](https://github.com/user-attachments/assets/121d7114-34fe-4a11-9d0a-1bbace483404) |
