### PR TITLE
markdown title colors

### DIFF
--- a/themes/one-dark.json
+++ b/themes/one-dark.json
@@ -277,6 +277,16 @@
             "color": "#e5c07b",
             "font_style": null,
             "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#d07277ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#d07277ff",
+            "font_style": null,
+            "font_weight": null
           }
         }
       }


### PR DESCRIPTION
This pr adds colors to the title for markdown like One Dark zed theme

before
![image](https://github.com/user-attachments/assets/5419c9f6-7637-4b0d-b423-c81660143f9b)


after
![image](https://github.com/user-attachments/assets/f474c41e-8b96-44d7-8170-c2a532979267)
