### PR TITLE
Make indent guides less distracting

### DIFF
--- a/themes/one-dark.json
+++ b/themes/one-dark.json
@@ -59,6 +59,8 @@
         "editor.line_number": "#495162",
         "editor.active_line_number": "#abb2bf",
         "editor.invisible": null,
+        "editor.indent_guide": "#3b4048",
+        "editor.indent_guide_active": "#c8c8c859",
         "editor.wrap_guide": "#3e4452",
         "editor.active_wrap_guide": "#3e4452",
         "editor.document_highlight.read_background": "#555a6345",


### PR DESCRIPTION
I added colors for the indent guides to make them less distracting. The colors are sourced from the [VSCode Extension](https://github.com/Binaryify/OneDark-Pro/blob/6305452802975b158e34dfe634de02153bdcc34a/themes/OneDark-Pro.json#L2179).

### Before
<img width="737" height="519" alt="zed_one_dark_before" src="https://github.com/user-attachments/assets/5046b6df-14d3-40e1-8d42-c822fa8827ad" />

### After
<img width="737" height="519" alt="zed_one_dark_after" src="https://github.com/user-attachments/assets/695384cb-97a9-434c-a46b-f8b32073df3e" />